### PR TITLE
improve ubuntu install docs

### DIFF
--- a/docs/install/ubuntu.md
+++ b/docs/install/ubuntu.md
@@ -8,7 +8,6 @@ import Blockquote from "@/components/Blockquote"
 
 A full guide for installing, configuring and running LogChimp on your **Ubuntu 20.04** server, for use in production.
 
-
 ## Overview
 
 This the official guide for self-hosting LogChimp using our recommended stack of Ubuntu 20.04. If you’re comfortable installing, maintaining and updating your own software, this is the place for you. By the end of this guide you’ll have a fully configured LogChimp install running in production.
@@ -120,7 +119,6 @@ CREATE DATABASE <database name>;
   Wrap your password in single quotes. Also, do not forget to add the semicolon at the end of commands.
 </Blockquote>
 
-
 ```bash
 # Then exit postgresql prompt
 \q
@@ -197,12 +195,11 @@ sudo yarn
   The name of the unzipped folder may change after new releases. To confirm the name of the unzipped folder, type the command ls and press enter. The folder will be shown alongside logchimp-server.tar.gz. 
 </Blockquote>
 
-
 #### Configuration
 
 You will now create the `logchimp.config.json` [configuation file](/docs/config) in the current directory. There are three ways to create the configuration file.
 
-The first to create it manually. To do this, run the command `sudo nano logchimp.config.js` and type in the configuration manually. Press Ctrl/Command + X to save and exit. 
+The first to create it manually. To do this, run the command `sudo nano logchimp.config.js` and type in the configuration manually. Press Ctrl/Command + X to save and exit.
 
 The other two ways use the `logchimp-cli` tool.
 
@@ -248,7 +245,7 @@ LOGCHIMP_MAIL_PASSWORD=mail_password
 
 Be sure to set the correct values for the database user, password and database, and choose a random value for LOGCHIMP_SECRET_KEY as it is used for hashing.
 
-Press Ctrl/Command + X  then Y to save the file.
+Press Ctrl/Command + X then Y to save the file.
 
 Run the following command which creates the configuration file based on environment variables you set in .env.
 
@@ -264,7 +261,7 @@ You can run the following command to see the contents of the configuration file 
 cat logchimp.config.json
 ```
 
-###  Initializing database tables
+### Initializing database tables
 
 Run the following command to set creates all the tables that logchimp needs in your database:
 
@@ -338,10 +335,9 @@ yarn
 yarn build
 ```
 
-After a successful build, a  `dist` folder should be created in your current directory. This folder contains the frontend code that your user's browsers will receive when they visit your site.
+After a successful build, a `dist` folder should be created in your current directory. This folder contains the frontend code that your user's browsers will receive when they visit your site.
 
 To customise the build, you can download the source code directly from [GitHub](https://github.com/logchimp/theme).
-
 
 ## Setup Nginx
 
@@ -401,6 +397,6 @@ sudo certbot --nginx -d <your_domain>
 <Blockquote type="warning">
   Enter the same domain name you've used while creating Nginx configuration.
 </Blockquote>
-`certbot` will ask how you would like to configure your HTTPS settings. Select `2` (redirect) and hit `Enter`. The configuration will be updated, and Nginx will reload to pick up the new settings.
+Finally, `certbot` will ask how you would like to configure your HTTPS settings. Select `2` (redirect) and hit `Enter`. The configuration will be updated, and Nginx will reload to pick up the new settings.
 
 **🎉 Congrats!** You've successfully setup your own LogChimp site. You can now visit your domain to see your LogChimp site and create the admin account.

--- a/docs/install/ubuntu.md
+++ b/docs/install/ubuntu.md
@@ -12,7 +12,7 @@ A full guide for installing, configuring and running LogChimp on your **Ubuntu 2
 
 This the official guide for self-hosting LogChimp using our recommended stack of Ubuntu 20.04. If you’re comfortable installing, maintaining and updating your own software, this is the place for you. By the end of this guide you’ll have a fully configured LogChimp install running in production.
 
-You can use this 👉 [DigitalOcean](https://m.do.co/c/bb349ea15324) 👈 link and get **free $100 credit** to run your servers.
+You can use this 👉 [DigitalOcean](https://m.do.co/c/bb349ea15324) 👈 link and get **free $100 credit** to self-host.
 
 <Blockquote type="tip">
 Save time with LogChimp VALET.


### PR DESCRIPTION
The old ubuntu installation docs was a difficult to follow and had few errors which I fixed here.

https://website-git-improve-install-docs-okezieuc.vercel.app/docs/install/ubuntu.

Everything works fine, but the only problem is that when I try to create the owner account the api call keeps loading and I get the following error on the backend
```
(node:29967) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'userId' of undefined
    at module.exports (/var/www/logchimp/server/logchimp/server/controllers/auth/setup.js:56:17)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:29967) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:29967) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

When I check if the user was created with `SELECT * from users`, I will find the user is created successfully but the user is not set as the owner. Same kind of error shows when I try to login to the account I created.

Do you have any idea why this is happening?
BTW I don't have mail set up but that shouldn't be the cause.